### PR TITLE
feat: add thermostat support

### DIFF
--- a/custom_components/nexo/__init__.py
+++ b/custom_components/nexo/__init__.py
@@ -11,7 +11,14 @@ from .const import DOMAIN
 from .nexoBridge import NexoBridge
 
 _LOGGER: Final = logging.getLogger(__name__)
-PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH, Platform.COVER]
+PLATFORMS: list[Platform] = [
+    Platform.LIGHT,
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.COVER,
+    Platform.CLIMATE,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/nexo/climate.py
+++ b/custom_components/nexo/climate.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+import logging
+import string
+from typing import Any, Final
+from homeassistant.components.climate.const import (
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from .nexo_thermostat import NexoThermostat
+from .const import DOMAIN
+
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up"""
+    nexo = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HANexoClimate(thermostat)
+        for thermostat in nexo.get_resources_by_type(NexoThermostat)
+    )
+
+
+class HANexoClimate(ClimateEntity):
+    """Home Assistant Nexo Climate"""
+
+    def __init__(self, nexo_termostat) -> None:
+        super().__init__()
+        self.nexo_termostat = nexo_termostat
+        self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+        self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL]
+        self._attr_hvac_actions = [
+            HVACAction.COOLING,
+            HVACAction.HEATING,
+            HVACAction.OFF,
+        ]
+        self._attr_target_temperature_low = nexo_termostat.min
+        self._attr_target_temperature_high = nexo_termostat.max
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this output."""
+        return str(self.nexo_termostat.name)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the id of this Nexo thermostat."""
+        return str(self.nexo_termostat.id)
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        return self.nexo_termostat.get_havac_mode()
+
+    @property
+    def hvac_action(self) -> HVACAction:
+        """Return the current HVAC action."""
+        return self.nexo_termostat.get_hvac_action()
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the current temperature."""
+        return self.nexo_termostat.get_value()
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Set the HVAC mode."""
+        if hvac_mode == HVACMode.OFF:
+            self.nexo_termostat.turn_off()
+        else:
+            self.nexo_termostat.turn_on()
+
+    async def async_set_temperature(self, **kwargs):
+        """Set the target temperature."""
+        self.nexo_termostat.set_value(kwargs["temperature"])
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the state of the entity."""
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Run when this Entity has been added to HA."""
+        # Nexo Light should also register callbacks to HA when their state changes
+        self.nexo_termostat.register_callback(self.async_update_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        # The opposite of async_added_to_hass. Remove any registered call backs here.
+        self.nexo_termostat.remove_callback(self.async_update_state)

--- a/custom_components/nexo/nexoBridge.py
+++ b/custom_components/nexo/nexoBridge.py
@@ -12,6 +12,7 @@ from .nexo_binary_sensor import NexoBinarySensor
 from .nexo_analog_sensor import NexoAnalogSensor
 from .nexo_output import NexoOutput
 from .nexo_temperature import NexoTemperature
+from .nexo_thermostat import NexoThermostat
 from .nexo_blind_group import NexoBlindGroup
 from .nexo_group_dimmer import NexoGroupDimmer
 from .nexo_gate import NexoGate
@@ -112,6 +113,11 @@ class NexoBridge:
             return self.resources[int(resource_id)]
         return None
 
+    def get_resources_by_exact_type(self, resource_type):
+        return list(
+            filter(lambda x: type(x) is resource_type, list(self.resources.values()))
+        )
+
     def get_resources_by_type(self, resource_type):
         return list(
             filter(
@@ -149,10 +155,15 @@ class NexoBridge:
                 return obj
 
             case "temperature":
-                if not ('thermometer_id' in nexo_resource):
-                    obj = NexoTemperature(self.ws, **nexo_resource)
-                    self.resources[obj.id] = obj
-                    return obj
+                match nexo_resource["mode"]:
+                    case 1:
+                        obj = NexoTemperature(self.ws, **nexo_resource)
+                    case 2:
+                        obj = NexoThermostat(self.ws, **nexo_resource)
+                    case _:
+                        return None
+                self.resources[obj.id] = obj
+                return obj
 
             case "blind":
                 obj = NexoBlind(self.ws, **nexo_resource)

--- a/custom_components/nexo/nexo_thermostat.py
+++ b/custom_components/nexo/nexo_thermostat.py
@@ -1,0 +1,54 @@
+from .nexo_temperature import NexoTemperature
+from homeassistant.components.climate.const import (
+    HVACAction,
+    HVACMode,
+)
+
+
+class NexoThermostat(NexoTemperature):
+    """Nexo thermostat sensor"""
+
+    def __init__(self, web_socket, min, max, *args, **kwargs):
+        """Initialize the Nexo thermostat sensor."""
+        super().__init__(web_socket, *args, **kwargs)
+        self.min = min
+        self.max = max
+
+    def get_havac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        if bool(self._get_is_on()):
+            return HVACMode.HEAT_COOL
+        return HVACMode.OFF
+
+    def get_hvac_action(self) -> HVACAction:
+        """Return the current HVAC action."""
+        if not bool(self._get_is_on()):
+            return HVACAction.OFF
+        if bool(self.state["is_active"]):
+            return HVACAction.COOLING
+        return HVACAction.HEATING
+
+    def turn_on(self):
+        """Turn on the thermostat."""
+        self.web_socket.send(self._get_message(1))
+
+    def turn_off(self):
+        """Turn off the thermostat."""
+        self.web_socket.send(self._get_message(0))
+
+    def toggle(self):
+        """Toggle the thermostat."""
+        self.web_socket.send(self._get_message(1 if self._get_is_on() == 0 else 0))
+
+    def set_value(self, value):
+        """Set the target temperature."""
+        value = int(value * 10)
+        self.web_socket.send(self._get_message(self._get_is_on(), value))
+
+    def _get_is_on(self):
+        """Return the current state of the thermostat."""
+        return self.state["is_on"]
+
+    def _get_message(self, operation, value=32767):
+        """Return the message to send to the thermostat."""
+        return f'{{"type": "resource", "id": {self.id}, "cmd":{{"operation":{operation},"value":{value}}} }}'

--- a/custom_components/nexo/sensor.py
+++ b/custom_components/nexo/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     for sensor in nexo.get_resources_by_type(NexoAnalogSensor):
         sensors.insert(0, HANexoAnalogSensor(sensor))
 
-    for temp in nexo.get_resources_by_type(NexoTemperature):
+    for temp in nexo.get_resources_by_exact_type(NexoTemperature):
         temperature_sensors.insert(0, HANexoTemperatureSensor(temp))
 
     async_add_entities(sensors)


### PR DESCRIPTION
This pull request introduces support for climate entities in the Nexo integration, including the addition of a `NexoThermostat` class and corresponding changes to integrate it with Home Assistant. The key changes are grouped into two themes: climate entity support and refactoring for resource type handling.

### Climate Entity Support:
* Added a new `HANexoClimate` class in `custom_components/nexo/climate.py` to represent climate entities in Home Assistant, supporting features like target temperature, HVAC modes, and actions.
* Introduced a `NexoThermostat` class in `custom_components/nexo/nexo_thermostat.py`, extending `NexoTemperature` to handle thermostat-specific functionality, such as HVAC mode, HVAC action, and temperature control.
* Updated the `PLATFORMS` list in `custom_components/nexo/__init__.py` to include `Platform.CLIMATE`, enabling the integration to register climate entities.

### Refactoring for Resource Type Handling:
* Added a `get_resources_by_exact_type` method in `custom_components/nexo/nexoBridge.py` to filter resources by their exact class type, improving resource management.
* Updated the `add_resource` method in `custom_components/nexo/nexoBridge.py` to differentiate between `NexoTemperature` and `NexoThermostat` based on the `mode` attribute in the resource data.
* Modified `async_setup_entry` in `custom_components/nexo/sensor.py` to use `get_resources_by_exact_type` for handling temperature sensors, ensuring thermostats are excluded.