### PR TITLE
fix: regression affecting binary sensors

### DIFF
--- a/custom_components/nexo/nexoBridge.py
+++ b/custom_components/nexo/nexoBridge.py
@@ -140,6 +140,8 @@ class NexoBridge:
                 return obj
 
             case "sensor":
+                if "state" not in nexo_resource:
+                    return None
                 obj = NexoBinarySensor(self.ws, **nexo_resource)
                 self.resources[obj.id] = obj
                 return obj


### PR DESCRIPTION
This pull request introduces a small but important update to the add_resource method in nexoBridge.py. It adds a validation step to ensure that the nexo_resource dictionary contains the "state" key before attempting to create a NexoBinarySensor object. If the "state" key is missing, the method now returns None, preventing the creation of an invalid sensor object.

This change addresses an issue where Nexo duplicates contact sensors ("styk"). The duplicated entries lack the "state" key, which can lead to errors if not properly handled.

Fixes #6