### PR TITLE
Fix: Add supported_color_modes to HANexoLight for HA 2025.3 compatibility

### DIFF
--- a/custom_components/nexo/light.py
+++ b/custom_components/nexo/light.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Final
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.components.light import LightEntity
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,7 +29,8 @@ class HANexoLight(LightEntity):
         super().__init__()
         self._nexolight = nexo_light
         self._name = nexo_light.name
-        self._attr_is_on = self._nexolight.is_on()
+        self._attr_supported_color_modes = ColorMode.ONOFF
+        self._attr_color_mode = ColorMode.ONOFF
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
This pull request updates the `custom_components/nexo/light.py` file to enhance the handling of light color modes by introducing support for `ColorMode`. The changes ensure better alignment with Home Assistant's light platform standards.

### Enhancements to light color mode handling:

* [`custom_components/nexo/light.py`](diffhunk://#diff-752e156d2b7c85568ebaee228908d9fc9bd108873daf92ab3e2a9a8081ca71faL7-R7): Imported `ColorMode` from `homeassistant.components.light` to enable the use of predefined color mode constants.
* [`custom_components/nexo/light.py`](diffhunk://#diff-752e156d2b7c85568ebaee228908d9fc9bd108873daf92ab3e2a9a8081ca71faL32-R33): Updated the `__init__` method to set `_attr_supported_color_modes` and `_attr_color_mode` attributes to `ColorMode.ONOFF`, replacing the previous `_attr_is_on` assignment. This change standardizes the light's color mode handling.…lity