### PR TITLE
Fix sensor setup to use HANexoAnalogSensor

### DIFF
--- a/custom_components/nexo/sensor.py
+++ b/custom_components/nexo/sensor.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
     """Set up."""
     nexo: NexoBridge = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        NexoAnalogSensor(sensor)
+        HANexoAnalogSensor(sensor)
         for sensor in nexo.get_resources_by_type(NexoAnalogSensor)
     )
     async_add_entities(


### PR DESCRIPTION
This pull request includes a small change to the `custom_components/nexo/sensor.py` file. The change updates the sensor class from `NexoAnalogSensor` to `HANexoAnalogSensor` in the `async_setup_entry` function.
fixes #20